### PR TITLE
fix for overlapping grandchildren of multiple spouses

### DIFF
--- a/src/children/arrange.ts
+++ b/src/children/arrange.ts
@@ -28,7 +28,7 @@ const arrangeMiddleFamilies = (families: readonly Family[], fid: number, startFr
   const family: Family | undefined = families[start];
 
   if (family) {
-    const shift: number = startFrom - family.X;
+    const shift: number = startFrom - family.X + 1;
     for (let i = start; i < families.length; i++) families[i]!.X += shift;
   }
 };


### PR DESCRIPTION
If I create multiple spouses of any of my parents and then create multiple grandchildren(at least 4 or 5) of each spouse then the grandchildren are overlapping.
Please merge this PR in case if anyone is facing the same issue will get this update.